### PR TITLE
Change table access to optionally not create tables if they do not exist

### DIFF
--- a/src/buzz/argos/buzz_loop_functions.cpp
+++ b/src/buzz/argos/buzz_loop_functions.cpp
@@ -49,15 +49,20 @@ void BuzzPut(buzzvm_t t_vm,
 /****************************************/
 /****************************************/
 
-void BuzzTableOpen(buzzvm_t t_vm,
-                   const std::string& str_var) {
+bool BuzzTableOpen(buzzvm_t t_vm,
+                   const std::string& str_var,
+                   bool b_create) {
    buzzvm_pushs(t_vm, buzzvm_string_register(t_vm, str_var.c_str(), 1));
    buzzvm_dup(t_vm);
    buzzvm_gload(t_vm);
    if(!buzzobj_istable(buzzvm_stack_at(t_vm, 1))) {
+      if(!b_create) {
+         return false;
+      }
       buzzvm_pop(t_vm);
       buzzvm_pusht(t_vm);
    }
+   return true;
 }
 
 /****************************************/
@@ -168,49 +173,64 @@ void BuzzTablePut(buzzvm_t t_vm,
 /****************************************/
 /****************************************/
 
-void BuzzTableOpenNested(buzzvm_t t_vm,
-                         int n_key) {
+bool BuzzTableOpenNested(buzzvm_t t_vm,
+                         int n_key,
+                         bool b_create) {
    buzzvm_dup(t_vm);
    buzzvm_pushi(t_vm, n_key);
    buzzvm_push(t_vm, buzzvm_stack_at(t_vm, 2));
    buzzvm_pushi(t_vm, n_key);
    buzzvm_tget(t_vm);
    if(!buzzobj_istable(buzzvm_stack_at(t_vm, 1))) {
+      if(!b_create) {
+         return false;
+      }
       buzzvm_pop(t_vm);
       buzzvm_pusht(t_vm);
    }
+   return true;
 }
 
 /****************************************/
 /****************************************/
 
-void BuzzTableOpenNested(buzzvm_t t_vm,
-                         float f_key) {
+bool BuzzTableOpenNested(buzzvm_t t_vm,
+                         float f_key,
+                         bool b_create) {
    buzzvm_dup(t_vm);
    buzzvm_pushf(t_vm, f_key);
    buzzvm_push(t_vm, buzzvm_stack_at(t_vm, 2));
    buzzvm_pushf(t_vm, f_key);
    buzzvm_tget(t_vm);
    if(!buzzobj_istable(buzzvm_stack_at(t_vm, 1))) {
+      if(!b_create) {
+         return false;
+      }
       buzzvm_pop(t_vm);
       buzzvm_pusht(t_vm);
    }
+   return true;
 }
 
 /****************************************/
 /****************************************/
 
-void BuzzTableOpenNested(buzzvm_t t_vm,
-                         const std::string& str_key) {
+bool BuzzTableOpenNested(buzzvm_t t_vm,
+                         const std::string& str_key,
+                         bool b_create) {
    buzzvm_dup(t_vm);
    buzzvm_pushs(t_vm, buzzvm_string_register(t_vm, str_key.c_str(), 0));
    buzzvm_push(t_vm, buzzvm_stack_at(t_vm, 2));
    buzzvm_pushs(t_vm, buzzvm_string_register(t_vm, str_key.c_str(), 0));
    buzzvm_tget(t_vm);
    if(!buzzobj_istable(buzzvm_stack_at(t_vm, 1))) {
+      if(!b_create) {
+         return false;
+      }
       buzzvm_pop(t_vm);
       buzzvm_pusht(t_vm);
    }
+   return true;
 }
 
 /****************************************/

--- a/src/buzz/argos/buzz_loop_functions.h
+++ b/src/buzz/argos/buzz_loop_functions.h
@@ -71,10 +71,13 @@ void BuzzPut(buzzvm_t t_vm,
  *
  * @param t_vm The Buzz VM.
  * @param str_var The variable name that stores the table.
+ * @param b_create Make the table if does not exists [default = true].
+ * @return bool if successfully opened the table.
  * @see BuzzTableClose
  */
-void BuzzTableOpen(buzzvm_t t_vm,
-                   const std::string& str_var);
+bool BuzzTableOpen(buzzvm_t t_vm,
+                   const std::string& str_var,
+                   bool b_create = true);
 
 /**
  * Closes the currently open table and stores it as a global variable.
@@ -221,10 +224,13 @@ void BuzzTablePut(buzzvm_t t_vm,
  *
  * @param t_vm The Buzz VM.
  * @param n_key The key.
+ * @param b_create Make the table if does not exists [default = true].
+ * @return bool if successfully opened the table.
  * @see BuzzTableCloseNested
  */
-void BuzzTableOpenNested(buzzvm_t t_vm,
-                         int n_key);
+bool BuzzTableOpenNested(buzzvm_t t_vm,
+                         int n_key,
+                         bool b_create = true);
 
 /**
  * Opens a table nested in the currently open table.
@@ -234,10 +240,13 @@ void BuzzTableOpenNested(buzzvm_t t_vm,
  *
  * @param t_vm The Buzz VM.
  * @param f_key The key.
+ * @param b_create Make the table if does not exists [default = true].
+ * @return bool if successfully opened the table.
  * @see BuzzTableCloseNested
  */
-void BuzzTableOpenNested(buzzvm_t t_vm,
-                         float f_key);
+bool BuzzTableOpenNested(buzzvm_t t_vm,
+                         float f_key,
+                         bool b_create = true);
 
 /**
  * Opens a table nested in the currently open table.
@@ -247,10 +256,13 @@ void BuzzTableOpenNested(buzzvm_t t_vm,
  *
  * @param t_vm The Buzz VM.
  * @param str_key The key.
+ * @param b_create Make the table if does not exists [default = true].
+ * @return bool if successfully opened the table.
  * @see BuzzTableCloseNested
  */
-void BuzzTableOpenNested(buzzvm_t t_vm,
-                         const std::string& str_key);
+bool BuzzTableOpenNested(buzzvm_t t_vm,
+                         const std::string& str_key,
+                         bool b_create = true);
 
 /**
  * Closes the currently open table and stores it in the parent table.


### PR DESCRIPTION
I would like to propose the following implementation changes to `BuzzTableOpen` and `BuzzTableOpenNested`.
- Addition of an optional parameter `make_if_not_exist` to specify whether the table should be created if it does not already exist and have it default to `true` for backwards compatibility.
- Change return type from `void` to `bool` to notify the user if the table open was successful.

Example Usage:
```cpp
bool success;

success = BuzzTableOpen(t_vm, "tbl", false);
if(!success)
    return;
success = BuzzTableOpenNested(t_vm, "A", false);
if(!success)
    return;
```